### PR TITLE
Fix responsive footer

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -1,7 +1,7 @@
 <footer class="flex place-content-center pb-24">
   <div class="container text-center mt-8 p-10 text-black dark:text-white">
     <div class="flex flex-col items-center">
-      <div class="flex items-center gap-1 mt-4 mb-4">
+      <div class="flex items-center flex-col sm:flex-row gap-3 sm:gap-1 mt-4 mb-4">
         <span class="text-[0.8125rem]/6">Una iniciativa de</span><a
           class="px-1 rounded-3xl hover:scale-110 transition dark:bg-white ml-1"
           href="https://midu.dev"
@@ -20,11 +20,11 @@
     </div>
     <div class="flex gap-2 place-content-center">
       <p
-        class="flex items-baseline gap-x-1 text-[0.8125rem]/6 text-gray-500 dark:text-gray-100"
+        class="sm:flex items-baseline gap-x-1 text-[0.8125rem]/6 text-gray-500 dark:text-gray-100"
       >
         Sígueme en
         <a
-          class="group relative isolate flex items-center rounded-lg px-2 py-0.5 text-[0.8125rem]/6 font-medium text-black/30 dark:text-purple-300 text-purple-600 transition gap-x-0.5 hover:scale-110"
+          class="group relative isolate flex items-center rounded-lg px-2 sm:py-0.5 py-2 text-[0.8125rem]/6 font-medium text-black/30 dark:text-purple-300 text-purple-600 transition gap-x-0.5 hover:scale-110"
           href="https://twitch.tv/midudev"
           ><svg
             class="flex-none h-6 w-6 dark:text-purple-300 text-purple-600"
@@ -39,7 +39,7 @@
             ></svg
           ><span class="self-baseline">twitch.tv/midudev</span></a
         ><a
-          class="group relative isolate flex items-center rounded-lg px-2 py-0.5 text-[0.8125rem]/6 font-medium text-sky-500 dark:text-sky-300 transition gap-x-0.5 hover:scale-110"
+          class="group relative isolate flex items-center rounded-lg px-2 sm:py-0.5 py-2 text-[0.8125rem]/6 font-medium text-sky-500 dark:text-sky-300 transition gap-x-0.5 hover:scale-110"
           href="https://twitter.com/midudev"
           ><svg
             class="text-sky-500 dark:text-sky-300 size-6"


### PR DESCRIPTION
Careful footer fix for small screen devices.
- Before (iPhone 12 example):
![image](https://github.com/user-attachments/assets/9e7932b8-4803-4ffd-b6a8-65fae3dbd051)
- After (iPhone 12 example):
![image](https://github.com/user-attachments/assets/8b8ead38-e617-4db1-b306-217b503b069f)
